### PR TITLE
fix:badgeData empty value work around added

### DIFF
--- a/lib/theme/config/badge/badge.dart
+++ b/lib/theme/config/badge/badge.dart
@@ -66,7 +66,7 @@ const Map<String, dynamic> badgeData = {
       }
     },
     "variant": {
-      "solid": {},
+      "solid": {"": ""},
       "outline": {"borderWidth": "\$1"}
     },
     "size": {


### PR DESCRIPTION
Resolver could not handle value under ' solid ' key being empty.