### PR TITLE
style(GSInput) remove lateral padding of input underlined field

### DIFF
--- a/lib/src/widgets/gs_input/gs_input.dart
+++ b/lib/src/widgets/gs_input/gs_input.dart
@@ -315,7 +315,9 @@ class _GSInputState extends State<GSInput> {
                           ? 10 + widget.prefixText!.length * 8
                           : widget.prefixIcon != null
                               ? 50
-                              : 15,
+                              : widget.variant == GSInputVariants.underlined
+                                  ? 0
+                                  : 15,
                       top: 10,
                       child: Text(widget.hintText!,
                           style: widget.hintStyle ??

--- a/lib/src/widgets/gs_input/gs_input.dart
+++ b/lib/src/widgets/gs_input/gs_input.dart
@@ -315,9 +315,7 @@ class _GSInputState extends State<GSInput> {
                           ? 10 + widget.prefixText!.length * 8
                           : widget.prefixIcon != null
                               ? 50
-                              : widget.variant == GSInputVariants.underlined
-                                  ? 0
-                                  : 15,
+                              : styler.padding?.horizontal ?? 15,
                       top: 10,
                       child: Text(widget.hintText!,
                           style: widget.hintStyle ??


### PR DESCRIPTION
Use the same padding value for hintText of the input field when it don't has a prefix icon or text.